### PR TITLE
`IOError` → `OSError`

### DIFF
--- a/pillow_jpls/jpls_image_file.py
+++ b/pillow_jpls/jpls_image_file.py
@@ -54,7 +54,7 @@ class JplsImageFile(ImageFile):
         header = _pycharls.read_header(buffer)
         mode = _mode(header.component_count, header.bits_per_sample)
         if mode is None:
-            raise IOError(f"Mode not supported: components: {header.component_count}, bits: {header.bits_per_sample}")
+            raise OSError(f"Mode not supported: components: {header.component_count}, bits: {header.bits_per_sample}")
 
         meta = _metadata(header)
         color_space = meta.get("color_space")


### PR DESCRIPTION
From https://docs.python.org/3/library/exceptions.html#IOError:

> The following exceptions are kept for compatibility with previous versions; starting from Python 3.3, they are aliases of [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError).
> 
> _exception_ **`EnvironmentError`**
> 
> _exception_ **`IOError`**
> 
> _exception_ **`WindowsError`**