### PR TITLE
Build wheels for Python 3.12

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -44,7 +44,7 @@ jobs:
           flake8 --count --max-line-length=120 --statistics pillow_jpls
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.10.2
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
The first version of cibuildwheels reported to support Python 3.12 appears to be [v2.16.2](https://github.com/pypa/cibuildwheel/releases/tag/v2.16.2):
> * 🛠 Updates CPython 3.12 version to 3.12.0, final release (https://github.com/pypa/cibuildwheel/pull/1635)

Will hopefully fix #20