### PR TITLE
Python 3.12 and Pillow 10

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -54,7 +54,8 @@ jobs:
           # Pillow requires zlib to compile for PyPy on Windows
           # PyPy builds dont support conan
           # Pillow doesn't build on musilinux'
-          CIBW_SKIP: cp27-* cp35-* pp* *-musllinux*
+          # Pillow doesn't have wheels for 32-bit Python 3.12
+          CIBW_SKIP: cp27-* cp35-* pp* *-musllinux* cp312-win32 cp312-manylinux_i686
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest -v {project}/test
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -51,12 +51,14 @@ jobs:
         env:
           # Python 2.7 not supported
           # Python 3.5 Deprecated
-          # Pillow requires zlib to compile for PyPy on Windows
           # PyPy builds dont support conan
           # Pillow doesn't build on musilinux'
+          # Only use released wheels for Pillow
           # Pillow doesn't have wheels for 32-bit Python 3.12
           CIBW_SKIP: cp27-* cp35-* pp* *-musllinux* cp312-win32 cp312-manylinux_i686
+          CIBW_BEFORE_BUILD: "pip install Pillow --only-binary=:all:"
           CIBW_TEST_REQUIRES: pytest numpy
+          CIBW_BEFORE_TEST: "pip install Pillow --only-binary=:all:"
           CIBW_TEST_COMMAND: pytest -v {project}/test
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_BUILD_VERBOSITY: 1

--- a/pillow_jpls/jpls_image_file.py
+++ b/pillow_jpls/jpls_image_file.py
@@ -71,5 +71,14 @@ class JplsImageFile(ImageFile):
 
         self.info.update(_metadata(header))
         self._size = (header.width, header.height)
-        self.mode = mode
+        self._mode = mode
         self.tile = [("jpeg_ls", (0, 0) + self.size, 0, (meta, ))]
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @mode.setter
+    def mode(self, mode: str):
+        """Setter, for Pillow <10 compatibility."""
+        self._mode = mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "pybind11~=2.6.0",
     "cmake",
-    "conan",
+    "conan~=1.62.0",
     "ninja",
     "scikit-build",
 ]


### PR DESCRIPTION
- Use binary Pillow when building wheel to avoid problems with building Pillow.
- Pin conan to not use conan 2.
- Add `mode`-property to  `JplsImageFile` to be compatible with Pillow 10.