### PR TITLE
Fix ci deprecate cp36

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
 
@@ -68,7 +68,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.15
 
       - name: Upload wheel files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
             path: ./wheelhouse/*.whl
 
@@ -76,12 +76,12 @@ jobs:
     name: Make SDist
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build SDist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -51,11 +51,12 @@ jobs:
         env:
           # Python 2.7 not supported
           # Python 3.5 Deprecated
+          # Python 3.6 Deprecated
           # PyPy builds dont support conan
           # Pillow doesn't build on musilinux'
           # Only use released wheels for Pillow
           # Pillow doesn't have wheels for 32-bit Python 3.12
-          CIBW_SKIP: cp27-* cp35-* pp* *-musllinux* cp312-win32 cp312-manylinux_i686
+          CIBW_SKIP: cp27-* cp35-* cp36-* pp* *-musllinux* cp312-win32 cp312-manylinux_i686
           CIBW_BEFORE_BUILD: "pip install Pillow --only-binary=:all:"
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_BEFORE_TEST: "pip install Pillow --only-binary=:all:"


### PR DESCRIPTION
FIx CI failures due to deprecation of Python 3.6
Fix some CI warnings due to outdated actions