### PR TITLE
Avoid warninng in CI job

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -52,7 +52,7 @@ jobs:
           # Pillow doesn't build on musilinux'
           # Only use released wheels for Pillow
           # Pillow doesn't have wheels for 32-bit Python 3.12
-          CIBW_SKIP: cp27-* cp35-* pp* *-musllinux* cp312-win32 cp312-manylinux_i686
+          CIBW_SKIP: pp* *-musllinux* cp312-win32 cp312-manylinux_i686
           CIBW_BEFORE_BUILD: "pip install Pillow --only-binary=:all:"
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_BEFORE_TEST: "pip install Pillow --only-binary=:all:"


### PR DESCRIPTION
cibuildwheel 2.x no longer supports Python < 3.6, versions 2.7 and 3.5 will be skipped any way.

This fixes this warning in CI jobs such as [19931460792](https://github.com/planetmarshall/pillow-jpls/actions/runs/7316646722/job/19931460792):
```
cibuildwheel 2.x no longer supports Python < 3.6. Please use the 1.x series or update CIBW_SKIP
```