### PR TITLE
Consistent, updated GitHub Actions across workflows

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -33,7 +33,7 @@ jobs:
           lfs: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.12
 

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -43,6 +43,6 @@ jobs:
           ms_print ${MASSIF_FILE}
 
       - name: Upload log files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: massif.*


### PR DESCRIPTION
I avoided very recent releases on purpose:
* [`actions/setup-python@v5`](https://github.com/actions/setup-python/tags) released 3 weeks ago
* [`actions/download-artifact@v4`](https://github.com/actions/download-artifact/tags) released last week
* [`actions/upload-artifact@v4`](https://github.com/actions/upload-artifact/tags) released last week